### PR TITLE
feat: 添加情绪衰减周期配置并优化错误处理

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -49,28 +49,14 @@
         "description": "LLM 提供商 ID（留空则使用当前会话默认）",
         "type": "string",
         "default": ""
-      },
-      "api_key": {
-        "description": "API Key（若提供商需要）",
-        "type": "string",
-        "default": ""
-      },
-      "api_base": {
-        "description": "API Base URL（可选）",
-        "type": "string",
-        "default": ""
-      },
-      "model": {
-        "description": "模型名称",
-        "type": "string",
-        "default": "gpt-3.5-turbo"
-      },
-      "context_length": {
-        "description": "每次调用传入的历史消息条数",
-        "type": "int",
-        "default": 5
       }
     }
+  },
+  "decay_duration_hours": {
+    "description": "情绪衰减周期（小时）",
+    "type": "float",
+    "default": 2.0,
+    "hint": "当前情绪值回归基线所需的时间。数值越大，情绪变化持续越久。"
   },
   "idle_check_enabled": {
     "description": "是否启用长时间未互动检测",

--- a/decay.py
+++ b/decay.py
@@ -91,7 +91,7 @@ class DecayManager:
                 deviation = current - base
                 if abs(deviation) < 0.001:
                     continue
-                duration = 2.0
+                duration = self.config.get("decay_duration_hours", 2.0)
                 delta = compute_decay(elapsed_hours_self, deviation, duration)
                 new_val = current + delta
                 new_val = max(0.0, min(50.0, new_val))
@@ -138,7 +138,7 @@ class DecayManager:
                 deviation = current - base
                 if abs(deviation) < 0.001:
                     continue
-                duration = 2.0
+                duration = self.config.get("decay_duration_hours", 2.0)
                 delta = compute_decay(elapsed_user, deviation, duration)
                 new_val = current + delta
                 new_val = max(0.0, min(50.0, new_val))

--- a/main.py
+++ b/main.py
@@ -7,13 +7,12 @@ AstrBot 插件：弗洛伊德双驱情绪管理
 import asyncio
 import shutil
 import time
-from pathlib import Path
+import traceback
 from typing import Dict
 
 from astrbot.api.event import filter, AstrMessageEvent
-from astrbot.api.star import Context, Star, register
+from astrbot.api.star import Context, Star, register, StarTools
 from astrbot.api import logger, AstrBotConfig
-from astrbot.core.utils.astrbot_path import get_astrbot_data_path
 
 from .storage import UserDataStorage, SelfDataStorage
 from .unconscious import UnconsciousAdjuster
@@ -80,7 +79,7 @@ EMOTION_REFERENCE_TABLE = """
 """
 
 
-@register("eros_thanatos", "Soulter", "弗洛伊德双驱情绪管理插件", "2.3.0")
+@register("astrbot_plugin_affection", "middcom,dream,deepseek", "弗洛伊德双驱情绪管理插件", "v1.2")
 class ErosThanatosPlugin(Star):
     """
     弗洛伊德双驱情绪管理插件主类
@@ -93,9 +92,7 @@ class ErosThanatosPlugin(Star):
         self.config = config
 
         # 基础数据目录
-        self.base_data_path = (
-            Path(get_astrbot_data_path()) / "plugin_data" / "eros_thanatos"
-        )
+        self.base_data_path = StarTools.get_data_dir()
         self.base_data_path.mkdir(parents=True, exist_ok=True)
 
         # 缓存每个机器人的存储实例和衰减管理器
@@ -248,7 +245,11 @@ class ErosThanatosPlugin(Star):
         # 仅追加一行提示，引导 LLM 遵循人设中的规则
         reminder = "（请根据上述数值和你在人设中定义的「情绪驱动规则」来演绎角色，不要提及数值。）"
 
-        req.system_prompt += "\n\n" + values_text + reminder
+        emotion_prompt = values_text + reminder
+        if req.system_prompt:
+            req.system_prompt += "\n\n" + emotion_prompt
+        else:
+            req.system_prompt = emotion_prompt
 
         if self.config.get("debug_mode"):
             logger.info(
@@ -416,7 +417,7 @@ class ErosThanatosPlugin(Star):
                 )
 
         except Exception as e:
-            logger.error(f"[ErosThanatos] 机器人 {bot_id} 用户 {uid} 更新失败: {e}")
+            logger.error(f"[ErosThanatos] 机器人 {bot_id} 用户 {uid} 更新失败: {e}\n{traceback.format_exc()}")
 
     # ---------- 用户指令 ----------
     @filter.command("mystatus")

--- a/storage.py
+++ b/storage.py
@@ -10,6 +10,8 @@ from copy import deepcopy
 import asyncio
 import time
 
+from astrbot.api import logger
+
 
 class SelfDataStorage:
     """机器人自身情绪数据存储器（每个机器人独立）"""
@@ -24,7 +26,11 @@ class SelfDataStorage:
             try:
                 with open(self.file_path, "r", encoding="utf-8") as f:
                     return json.load(f)
-            except Exception:
+            except json.JSONDecodeError as e:
+                logger.warning(f"[SelfDataStorage] JSON 解析失败 {self.file_path}: {e}")
+                return {}
+            except Exception as e:
+                logger.warning(f"[SelfDataStorage] 文件读取失败 {self.file_path}: {e}")
                 return {}
         return {}
 
@@ -34,7 +40,7 @@ class SelfDataStorage:
 
     async def async_save(self):
         async with self._lock:
-            self._save()
+            await asyncio.to_thread(self._save)
 
     def get(self) -> dict:
         return deepcopy(self.data)
@@ -81,7 +87,11 @@ class UserDataStorage:
             try:
                 with open(self.file_path, "r", encoding="utf-8") as f:
                     return json.load(f)
-            except Exception:
+            except json.JSONDecodeError as e:
+                logger.warning(f"[UserDataStorage] JSON 解析失败 {self.file_path}: {e}")
+                return {}
+            except Exception as e:
+                logger.warning(f"[UserDataStorage] 文件读取失败 {self.file_path}: {e}")
                 return {}
         return {}
 
@@ -91,7 +101,7 @@ class UserDataStorage:
 
     async def async_save(self):
         async with self._lock:
-            self._save()
+            await asyncio.to_thread(self._save)
 
     def _migrate_old_data(self):
         """将旧版用户数据中的自身字段迁移到全局自身存储"""


### PR DESCRIPTION
将硬编码的衰减周期改为从配置中读取，默认值为2.0小时
在storage模块中添加更详细的错误日志记录
使用asyncio.to_thread优化异步保存操作
简化配置schema，移除不必要的LLM配置项